### PR TITLE
Bug - Disable Multi-tow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ MF-Tow is also fully compatible with the popular '=BTC=_Logistic (DayZ Epoch Ver
 - Disable towing of locked vehicles (optional)
 - Requires a player to have a toolbox in their inventory in order to be able to attach a tow.
 
-## Configuring Tow Vehicles ##
+## Configuration ##
+
+### Configuring tow vehicles & towable vehicles ###
 
 [Download](https://github.com/matt-d-rat/mf-tow/archive/master.zip) and extract the zip file to a folder called ```mf-tow```, inside you will find a file called ```init.sqf```, open this file up in a text editor.
 
@@ -54,8 +56,18 @@ So for example, we can see that the code above permits the ```ArmoredSUV_PMC``` 
 To add a new vehicle which can be used as a towing vehicle, add a new case to the switch statement and define an array of the types of vehicles which can be towed (be careful not to have a trailing comma after the last entry in the array!):
 
 ```sqf
-	case "Pickup_PK_INS_DZE": {_array = ["Motorcycle","Car"];};
+case "Pickup_PK_INS_DZE": {_array = ["Motorcycle","Car"];};
 ```
+
+### Enabling Multi-tow ###
+
+By default, towing vehicles which are currently towing another vehicle is disabled (patched in v1.1.1). To enable this functionality, set the ```MF_Tow_Multi_Towing``` variable in ```init.sqf``` to true.
+
+```sqf
+MF_Tow_Multi_Towing = true; // Warning, this is not recommended!
+```
+
+Although this may seem like a nice feature, in reality the only purpose it will probably serve is to allow people to troll one another. The choice is entirely yours though :-).
 
 ## Installation Guide ##
 
@@ -239,6 +251,10 @@ __Step 18: Repack ```dayz_server.pbo``` and upload it to your server.
 1. Vehicles which have been towed and detached must be entered at least once in order for the server to update the vehicles world postion, ensuring the vehicle remain at that position on server restart.
 
 ### Change Log ###
+
+#### v1.1.1 ###
+- Fixed exploit which allowed players to tow vehicles which were already being towed.
+- Fixed exploit which allowed players to tow vehicles which were already towing another vehicle. This functionality can be turned back on via the ```MF_Tow_Multi_Towing``` config param being set to true (default value is false). Be warned, turning this on produces "interesting" results and probably only serves as a means for trolling.
 
 #### v1.1.0 ###
 - Non-breaking changes to the check for whether the cursor target is a towable vehicle.

--- a/init.sqf
+++ b/init.sqf
@@ -3,15 +3,16 @@
  * The main script for initalising towing functionality. 
  *
  * Created by Matt Fairbrass (matt_d_rat)
- * Version: 1.1.0
+ * Version: 1.1.1
  * MIT Licence
  **/
 
 private ["_cursorTarget", "_towableVehicles", "_towableVehiclesTotal"];
 
 // Public variables
-MF_Tow_Base_Path		= "addons\mf-tow"; 			// The base path to the MF-Tow Folder.
-MF_Tow_Distance			= 10;						// Minimum distance (in meters) away from vehicle the tow truck must be to tow.
+MF_Tow_Base_Path		= "addons\mf-tow"; 		// The base path to the MF-Tow Folder.
+MF_Tow_Distance			= 10;					// Minimum distance (in meters) away from vehicle the tow truck must be to tow.
+MF_Tow_Multi_Towing	 	= false;				// Allow a vehicle which is towing another vehicle already to be towed by another tow. Disabled by default.
 
 // Functions
 
@@ -94,7 +95,7 @@ _towableVehiclesTotal = count (_towableVehicles);
 // Add the action to the players scroll wheel menu if the cursor target is a vehicle which can tow.
 if(_towableVehiclesTotal > 0) then {
 	if (s_player_towing < 0) then {
-		if(!(_cursorTarget getVariable ["MFTowInTow", false])) then {
+		if(!(_cursorTarget getVariable ["MFTowIsTowing", false])) then {
 			s_player_towing = player addAction ["Attach Tow", format["%1\tow_AttachTow.sqf", MF_Tow_Base_Path], _cursorTarget, 0, false, true, "",""];				
 		} else {
 			s_player_towing = player addAction ["Detach Tow", format["%1\tow_DetachTow.sqf", MF_Tow_Base_Path], _cursorTarget, 0, false, true, "",""];			

--- a/tow_AttachTow.sqf
+++ b/tow_AttachTow.sqf
@@ -3,7 +3,7 @@
  * The action for attaching the tow to another vehicle. 
  *
  * Created by Matt Fairbrass (matt_d_rat)
- * Version: 1.1.0
+ * Version: 1.1.1
  * MIT Licence
  **/
 
@@ -46,6 +46,16 @@ if(_IsNearVehicle > 0) then {
 	// Check if the vehicle we want to tow is locked
 	if((_vehicle getVariable ["MF_Tow_Cannot_Tow", false])) exitWith {
 		cutText [format["Cannot tow %1 because it is locked.", _vehicleNameText], "PLAIN DOWN"];
+	};
+	
+	// Check that the vehicle we want to tow is not already being towed by something else.
+	if((_vehicle getVariable ["MFTowInTow", false])) exitWith {
+		cutText [format["Cannot tow %1 because it is already being towed by another vehicle.", _vehicleNameText], "PLAIN DOWN"];
+	};
+	
+	// Check that the vehicle we want to tow is not already towing something else
+	if(!MF_Tow_Multi_Towing && (_vehicle getVariable ["MFTowIsTowing", false])) exitWith {
+		cutText [format["Cannot tow %1 because it is already towing another vehicle.", _vehicleNameText], "PLAIN DOWN"];
 	};
 	
 	_finished = false;
@@ -125,7 +135,8 @@ if(_IsNearVehicle > 0) then {
 				// Detach the player from the tow truck
 				detach player;
 				
-				_towTruck setVariable ["MFTowInTow", true, true];
+				_vehicle setVariable ["MFTowInTow", true, true];
+				_towTruck setVariable ["MFTowIsTowing", true, true];
 				_towTruck setVariable ["MFTowVehicleInTow", _vehicle, true];
 				
 				cutText [format["%1 has been attached to %2.", _vehicleNameText, _towTruckNameText], "PLAIN DOWN"];

--- a/tow_DetachTow.sqf
+++ b/tow_DetachTow.sqf
@@ -3,11 +3,11 @@
  * The action for detaching the tow from another vehicle. 
  *
  * Created by Matt Fairbrass (matt_d_rat)
- * Version: 1.1.0
+ * Version: 1.1.1
  * MIT Licence
  **/
  
-private ["_vehicle","_started","_finished","_animState","_isMedic","_vehicleNameText","_towTruckNameText","_towTruck","_inTow","_hasToolbox"];
+private ["_vehicle","_started","_finished","_animState","_isMedic","_vehicleNameText","_towTruckNameText","_towTruck","_isTowing","_hasToolbox"];
 
 if(DZE_ActionInProgress) exitWith { cutText [(localize "str_epoch_player_96") , "PLAIN DOWN"] };
 DZE_ActionInProgress = true;
@@ -20,14 +20,14 @@ _towTruck = _this select 3;
 _towTruckNameText = [_towTruck] call MF_Tow_Get_Vehicle_Name;
 
 // exit if no vehicle is in tow.
-_inTow = _towTruck getVariable ["MFTowInTow", false];
+_isTowing = _towTruck getVariable ["MFTowIsTowing", false];
 
-if(_inTow) then {
+if(_isTowing) then {
 
 	// Select the vehicle currently in tow
 	_vehicle = _towTruck getVariable ["MFTowVehicleInTow", objNull];
 
-	if(!(isNull _towTruck)) then {
+	if(!(isNull _vehicle)) then {
 		_vehicleNameText = [_vehicle] call MF_Tow_Get_Vehicle_Name;
 		_finished = false;		
 		_hasToolbox = "ItemToolbox" in (items player);
@@ -75,14 +75,16 @@ if(_inTow) then {
 		
 			detach _vehicle;
 			detach player;
-			_towTruck setVariable ["MFTowInTow", false, true];
+			
+			_vehicle setVariable ["MFTowInTow", false, true];
+			_towTruck setVariable ["MFTowIsTowing", false, true];
 			_towTruck setVariable ["MFTowVehicleInTow", objNull, true];
 			cutText [format["%1 has been detached from %2.", _vehicleNameText, _towTruckNameText], "PLAIN DOWN"];
 			
 			_vehicle setvelocity [0,0,1];
 		};
 	} else {
-		_towTruck setVariable ["MFTowInTow", false, true];
+		_towTruck setVariable ["MFTowIsTowing", false, true];
 		_towTruck setVariable ["MFTowVehicleInTow", objNull, true];	
 	};
 } else {


### PR DESCRIPTION
- Fixed exploit which allowed players to tow vehicles which were already
  being towed.
- Fixed exploit which allowed players to tow vehicles which were already
  towing another vehicle. This functionality can be turned back on via the
  MF_Tow_Multi_Towing config param being set to true (default value is
  false). Be warned, turning this on produces "interesting" results and
  probably only serves as a means for trolling.
